### PR TITLE
fix: Adaptation of the homepage button group for mobile devices.

### DIFF
--- a/src/components/Home/Top.tsx
+++ b/src/components/Home/Top.tsx
@@ -71,8 +71,13 @@ const Top = () => {
         </Box>
         <Typography data-aos='fade-down' className='text'>Bitcoin Layer2</Typography>
         <Typography data-aos='fade-down' className='text'>Network</Typography>
-        <Box display={'flex'} mt={'20px'} alignItems={'center'} gap={'10px'}>
-
+        <Box sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          marginTop: '20px',
+          alignItems: 'center',
+          gap: '10px',
+        }}>
           <Box
             data-aos='fade-up'
             className='paper'


### PR DESCRIPTION
**Mobile version:**

Before
<img width="375" alt="image" src="https://github.com/b2network/b-squared-fe/assets/87231192/b54258ae-0968-4ada-8b6b-55685cb76d09">

After
<img width="375" alt="image" src="https://github.com/b2network/b-squared-fe/assets/87231192/820794a3-18ab-47cc-b61e-124affa7a958">

**Desktop version:**
Before
<img width="1287" alt="image" src="https://github.com/b2network/b-squared-fe/assets/87231192/ecfcdfa0-5daa-4eb7-bf18-dd82d94485cc">

After
<img width="1289" alt="image" src="https://github.com/b2network/b-squared-fe/assets/87231192/ff227448-fdf4-4f5d-9a29-da82e3ade9f8">

